### PR TITLE
fix - make editor scale to user's code length up to 1000 lines

### DIFF
--- a/app/assets/stylesheets/views/_code_editor.scss
+++ b/app/assets/stylesheets/views/_code_editor.scss
@@ -1,9 +1,5 @@
 // Code editor styles
 
-#editor-wrapper {
-  
-}
-
 #editor {
   position: relative;
   top: 0;

--- a/app/assets/stylesheets/views/_code_editor.scss
+++ b/app/assets/stylesheets/views/_code_editor.scss
@@ -1,7 +1,7 @@
 // Code editor styles
 
 #editor-wrapper {
-  min-height: 400px;
+  
 }
 
 #editor {

--- a/app/assets/stylesheets/views/_code_editor.scss
+++ b/app/assets/stylesheets/views/_code_editor.scss
@@ -5,7 +5,7 @@
 }
 
 #editor {
-  position: absolute;
+  position: relative;
   top: 0;
   right: 0;
   bottom: 0;

--- a/app/views/posts/_editor.html.erb
+++ b/app/views/posts/_editor.html.erb
@@ -12,6 +12,7 @@
 			  editor.setHighlightActiveLine(false);
 			  editor.setShowPrintMargin(false);
 			  editor.getSession().setUseWrapMode(true);
+              editor.setOptions({maxLines: 100});
 
 				editor.getSession().on('change', function(e) {
 	    		code = editor.getSession().getValue();


### PR DESCRIPTION
edit editor css and editor settings to be relatively positioned, which
keeps the layout in tact while letting the box expand to up to 1000
lines.